### PR TITLE
JS and ampersands in titles

### DIFF
--- a/curriculum/2-core/1-web-standards.md
+++ b/curriculum/2-core/1-web-standards.md
@@ -49,7 +49,7 @@ Resources:
 
 - [Publishing your website](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/Publishing_your_website)
 
-## 1.2 The HTML, CSS, and JavaScript triangle
+## 1.2 The HTML, CSS, & JS triangle
 
 Learning outcomes:
 

--- a/curriculum/2-core/3-css-fundamentals.md
+++ b/curriculum/2-core/3-css-fundamentals.md
@@ -130,7 +130,7 @@ Resources:
 
 - [Cascade, specificity, and inheritance](https://developer.mozilla.org/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
 
-## 3.5 Values and units
+## 3.5 Values & units
 
 Learning outcomes:
 
@@ -174,7 +174,7 @@ Resources:
 
 - [Handling different text directions > Logical properties](https://developer.mozilla.org/docs/Learn/CSS/Building_blocks/Handling_different_text_directions#logical_properties_and_values)
 
-## 3.7 Backgrounds and borders
+## 3.7 Backgrounds & borders
 
 Learning outcomes:
 

--- a/curriculum/2-core/4-css-text-styling.md
+++ b/curriculum/2-core/4-css-text-styling.md
@@ -8,7 +8,7 @@ template: module
 
 This module focuses specifically on CSS font and text styling, including loading custom web fonts and applying them to your text.
 
-## 4.1 Text and font styling
+## 4.1 Text & font styling
 
 Learning outcomes:
 
@@ -34,7 +34,7 @@ Resources:
 
 - [Text and typography](https://web.dev/learn/css/typography/), web.dev (2021)
 
-## 4.2 Styling lists and links
+## 4.2 Styling lists & links
 
 Learning outcomes:
 

--- a/curriculum/2-core/6-javascript-fundamentals.md
+++ b/curriculum/2-core/6-javascript-fundamentals.md
@@ -4,7 +4,7 @@ topic: Scripting
 template: module
 ---
 
-# 6 JavaScript fundamentals
+# 6 JS fundamentals
 
 JavaScript is a huge topic, with so many different features, styles, and techniques to learn, and so many APIs and tools built on top of it. This module focuses mostly on the essentials of the core language, plus some key surrounding topics — learning these topics will give you a solid basis to work from.
 
@@ -212,7 +212,7 @@ Resources:
 
 - [Arrow function expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 
-## 6.8 JavaScript object basics
+## 6.8 JS object basics
 
 Learning outcomes:
 
@@ -288,7 +288,7 @@ Resources:
 
 - [Introduction to events](https://developer.mozilla.org/docs/Learn/JavaScript/Building_blocks/Events)
 
-## 6.11 Async JavaScript basics
+## 6.11 Async JS basics
 
 Learning outcomes:
 
@@ -356,7 +356,7 @@ Resources:
 
 - [Working with JSON](https://developer.mozilla.org/docs/Learn/JavaScript/Objects/JSON)
 
-## 6.14 Libraries and frameworks
+## 6.14 Libraries & frameworks
 
 Learning outcomes:
 
@@ -408,7 +408,7 @@ Resources:
 
 - [Introduction to client-side frameworks](https://developer.mozilla.org/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction)
 
-## 6.15 Debugging JavaScript
+## 6.15 Debugging JS
 
 Learning outcomes:
 

--- a/curriculum/2-core/7-accessibility.md
+++ b/curriculum/2-core/7-accessibility.md
@@ -94,7 +94,7 @@ Resources:
 
 - [Accessibility Design Guide](https://wiki.mozilla.org/Accessibility/Design_Guide), wiki.mozilla.org (2023)
 
-## 7.3 Accessible JavaScript
+## 7.3 Accessible JS
 
 Learning outcomes:
 

--- a/curriculum/3-extensions/3-web-apis.md
+++ b/curriculum/3-extensions/3-web-apis.md
@@ -17,7 +17,7 @@ General resources:
 
 - [Client-side web APIs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs)
 
-## 3.1 Video and audio APIs
+## 3.1 Video & audio APIs
 
 Learning outcomes:
 

--- a/curriculum/3-extensions/4-performance.md
+++ b/curriculum/3-extensions/4-performance.md
@@ -130,7 +130,7 @@ Resources:
 
 - Relevant Chrome DevTools: [Inspect network activity](https://developer.chrome.com/docs/devtools/network/) (2019) and [Analyze runtime performance](https://developer.chrome.com/docs/devtools/performance/) (2017), developer.chrome.com
 
-## 4.4 CSS and performance
+## 4.4 CSS & performance
 
 Learning outcomes:
 
@@ -148,7 +148,7 @@ Resources:
 
 - [CSS performance optimization](https://developer.mozilla.org/docs/Learn/Performance/CSS)
 
-## 4.5 JavaScript and performance
+## 4.5 JS & performance
 
 Learning outcomes:
 

--- a/curriculum/3-extensions/5-security-and-privacy.md
+++ b/curriculum/3-extensions/5-security-and-privacy.md
@@ -4,7 +4,7 @@ topic: Best Practices
 template: module
 ---
 
-# Extension 5: Security and privacy
+# Extension 5: Security & privacy
 
 It is vital to have an understanding of how you can and should protect your data and your user's data from would-be attackers who may try to steal it. This module covers both hardening websites to make it more difficult to steal data, and collecting user data in a respectful way that avoids tracking them or sharing it with unsuitable third parties.
 
@@ -14,7 +14,7 @@ General resources:
 
 - [Learn Privacy](https://web.dev/learn/privacy/), web.dev (2023)
 
-## 5.1 Security and privacy basics
+## 5.1 Security & privacy basics
 
 > **Notes**:
 >

--- a/curriculum/3-extensions/6-testing.md
+++ b/curriculum/3-extensions/6-testing.md
@@ -32,7 +32,7 @@ Learning outcomes:
 
   - Accessibility Testing: Ensuring that the web app can be used by people with disabilities, conforming to accessibility guidelines such as the Web Content Accessibility Guidelines (see also [Accessibility](../2-core/7-accessibility.md)).
 
-## 6.2 Functional and compat testing
+## 6.2 Functional & compat testing
 
 Learning outcomes:
 

--- a/curriculum/3-extensions/7-a-practical-understanding-of-javascript-frameworks.md
+++ b/curriculum/3-extensions/7-a-practical-understanding-of-javascript-frameworks.md
@@ -4,7 +4,7 @@ topic: Tooling
 template: module
 ---
 
-# Extension 7: JavaScript frameworks
+# Extension 7: JS frameworks
 
 JavaScript frameworks are commonly used by companies to build web applications. It is therefore beneficial to learn about popular frameworks and use cases (as listed below) for better employment prospects.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

As requested, in the PR I have updated all curriculum titles to change "JavaScript" to "JS", and "and" to "&".

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
