### PR TITLE
Fix core module 8 incorrect numbering

### DIFF
--- a/curriculum/2-core/8-design-for-developers.md
+++ b/curriculum/2-core/8-design-for-developers.md
@@ -30,7 +30,7 @@ General resources:
 
 - [Learn UI Design Fundamentals](https://scrimba.com/learn/design), Scrimba
 
-## 9.1 Basic design theory
+## 8.1 Basic design theory
 
 Learning outcomes:
 
@@ -56,7 +56,7 @@ Resources:
 
 - [Fundamental text and font styling](https://developer.mozilla.org/docs/Learn/CSS/Styling_text/Fundamentals)
 
-## 9.2 User-centered design
+## 8.2 User-centered design
 
 Learning outcomes:
 
@@ -92,7 +92,7 @@ Resources:
 
 - [Inclusive design principles](https://inclusivedesignprinciples.org/), inclusivedesignprinciples.org
 
-## 9.3 Design briefs
+## 8.3 Design briefs
 
 Learning outcomes:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

As per https://github.com/mdn/curriculum/issues/56, the submodule numbering on "Design for developers" is incorrect. This PR fixes it.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
