### PR TITLE
Update homepage crafting courses link

### DIFF
--- a/curriculum/0-README.md
+++ b/curriculum/0-README.md
@@ -48,7 +48,7 @@ Includes learning resource recommendations covering every curriculum topic, help
 
   [Getting started modules](./2-getting-started/)
 
-- ### Crafting courses?
+- ### Working at a school?
 
   _Utilize our modules to guide your teaching, or enroll your students in Scrimba's Frontend Developer Career Path._
 

--- a/curriculum/0-README.md
+++ b/curriculum/0-README.md
@@ -50,6 +50,6 @@ Includes learning resource recommendations covering every curriculum topic, help
 
 - ### Crafting courses?
 
-  _Utilize our modules to guide your teaching and support your students' learning journey._
+  _Utilize our modules to guide your teaching, or enroll your students in Scrimba's Frontend Developer Career Path._
 
-  [Core modules](./3-core/)
+  [Frontend path](https://v2.scrimba.com/the-frontend-developer-career-path-c0j?via=mdn)

--- a/curriculum/0-README.md
+++ b/curriculum/0-README.md
@@ -30,7 +30,7 @@ Includes learning resource recommendations covering every curriculum topic, help
 
 ## Don't know where to<br>get started? <!-- markdownlint-disable-line MD033 -->
 
-- ### Embarking on your coding journey?
+- ### Starting out with coding?
 
   _Begin with our "Getting started" and "Core" modules to grasp the essential skills for web development._
 
@@ -50,6 +50,6 @@ Includes learning resource recommendations covering every curriculum topic, help
 
 - ### Working at a school?
 
-  _Utilize our modules to guide your teaching, or enroll your students in Scrimba's Frontend Developer Career Path._
+  _Use our modules to guide your teaching, or enroll your students in Scrimba's Frontend Path._
 
-  [Frontend path](https://v2.scrimba.com/the-frontend-developer-career-path-c0j?via=mdn)
+  [Frontend Path](https://v2.scrimba.com/the-frontend-developer-career-path-c0j?via=mdn)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR updates the "Crafting courses" section on the landing page to offer the Scrimba FDCP as an option to teachers and link to it, rather than just repeating the link to the core modules landing page.

From Per at Scrimba:

> The “Don’t know where to get started” section currently has two items linking to the core modules, which is repetitive. Instead, I suggest the last one should be linked to the Frontend Path, with the angle of appealing to schools. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
