### PR TITLE
Fix for links to Inclusive Design Principles website

### DIFF
--- a/curriculum/3-core/8-design-for-developers.md
+++ b/curriculum/3-core/8-design-for-developers.md
@@ -92,7 +92,7 @@ Resources:
 
 - [Accessibility overview](https://developer.mozilla.org/docs/Learn/Accessibility)
 
-- [Inclusive design principles](https://inclusivedesignprinciples.org/), inclusivedesignprinciples.org
+- [Inclusive design principles](https://inclusivedesignprinciples.info/), inclusivedesignprinciples.info
 
 ## 8.3 Design briefs
 


### PR DESCRIPTION

### Description
Changed the TLD for inclusivedesignprinciples to point to the correct domain. Is currently pointing to DOTA slot/gambling site.

### Motivation
Noticed the link was wrong and wanted to make a change.

### Additional details
This correct domain is https://inclusivedesignprinciples.info

### Related issues and pull requests
Related issue that was resolved in https://github.com/mdn/content/issues/35316
