### PR TITLE
Fixed broken link

### DIFF
--- a/curriculum/3-core/8-design-for-developers.md
+++ b/curriculum/3-core/8-design-for-developers.md
@@ -92,7 +92,7 @@ Resources:
 
 - [Accessibility overview](https://developer.mozilla.org/docs/Learn/Accessibility)
 
-- [Inclusive design principles](https://inclusivedesignprinciples.org/), inclusivedesignprinciples.org
+- [Inclusive design principles](https://inclusivedesignprinciples.info/)
 
 ## 8.3 Design briefs
 


### PR DESCRIPTION
changed https://inclusivedesignprinciples.org/ to https://inclusivedesignprinciples.info



### Description
The first .org link led to a slot game site, the .info one leads to the actual inclusive design website.


### Motivation


