### PR TITLE
Repair bad link that ended up as a gambling site

### DIFF
--- a/curriculum/3-core/8-design-for-developers.md
+++ b/curriculum/3-core/8-design-for-developers.md
@@ -94,7 +94,7 @@ Resources:
 
 - [Accessibility overview](https://developer.mozilla.org/docs/Learn/Accessibility)
 
-- [Inclusive design principles](https://inclusivedesignprinciples.org/), inclusivedesignprinciples.org
+- [Inclusive design principles](https://inclusivedesignprinciples.info/), inclusivedesignprinciples.info
 
 ## 8.3 Design briefs
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

in [8.2 User-centered design](https://developer.mozilla.org/en-US/curriculum/core/design-for-developers/#8.2_user-centered_design), we link to the Inclusive Design Principles site.

We were linking to `inclusivedesignprinciples.org/`, which unfortunately has been taken over by a gambling/spam site.

This PR corrects that link to https://inclusivedesignprinciples.info/, which goes to the correct place.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
