### PR TITLE
feat: Add summaries to pages where it's missing

### DIFF
--- a/curriculum/0-README.md
+++ b/curriculum/0-README.md
@@ -1,5 +1,6 @@
 ---
 template: landing
+summary: The MDN Curriculum provides a structured guide to the essential skills and practices for being a successful front-end developer, along with recommended learning resources.
 ---
 
 # MDN Curriculum

--- a/curriculum/1-about-curriculum.md
+++ b/curriculum/1-about-curriculum.md
@@ -1,5 +1,6 @@
 ---
 template: about
+summary: This page describes the MDN front-end developer curriculum, including its motivation, target audience, scope, and update process as a guide to essential front-end web development skills.
 ---
 
 # About Curriculum

--- a/curriculum/2-getting-started/0-README.md
+++ b/curriculum/2-getting-started/0-README.md
@@ -1,5 +1,6 @@
 ---
 template: overview
+summary: Before diving into learning with the MDN curriculum, explore foundational topics like soft skills and environment setup to support your success in the core web development modules.
 ---
 
 # Getting started modules

--- a/curriculum/3-core/0-README.md
+++ b/curriculum/3-core/0-README.md
@@ -1,5 +1,6 @@
 ---
 template: overview
+summary: This page lists all core modules in the MDN front-end developer curriculum, covering essential topics like HTML, CSS, JavaScript, accessibility, and version control to build a solid foundation in front-end web development.
 ---
 
 # Core modules

--- a/curriculum/4-extensions/0-README.md
+++ b/curriculum/4-extensions/0-README.md
@@ -1,5 +1,6 @@
 ---
 template: overview
+summary: This page lists all extension modules in the MDN front-end developer curriculum, covering advanced topics like animation, Web APIs, performance, security, testing, and frameworks to help developers deepen their expertise.
 ---
 
 # Extensions modules

--- a/curriculum/5-faq.md
+++ b/curriculum/5-faq.md
@@ -1,5 +1,6 @@
 ---
 template: default
+summary: This page answers common questions about the MDN front-end developer curriculum, including its goals, content partners, and how the curriculum is maintained.
 ---
 
 # Frequently asked questions

--- a/curriculum/6-resources-for-educators.md
+++ b/curriculum/6-resources-for-educators.md
@@ -1,5 +1,6 @@
 ---
 template: about
+summary: This page provides guidance and tools to help educators adapt the MDN front-end developer curriculum for their own programs, including advice on scope, learning pathways, and assessments.
 ---
 
 # Resources for Educators


### PR DESCRIPTION
### Description

These pages fall back to boilerplate meta descriptions. Adding a summary to fix this.

## TODO

- [ ] Verify these are picked up correctly in rari

