### PR TITLE
Replace resource link in semantic html module, lists section

### DIFF
--- a/curriculum/3-core/2-semantic-html.md
+++ b/curriculum/3-core/2-semantic-html.md
@@ -110,7 +110,7 @@ Learning outcomes:
 
 Resources:
 
-- [HTML text fundamentals > Lists](https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#lists)
+- [HTML text fundamentals > Lists](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Lists)
 
 - [Advanced text formatting > Description lists](https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting#description_lists)
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Replaces resource link in Semantic HTML module to link to the proper page

### Motivation

Flagged by user @mirunacurtean in #83. I viewed the page and found that it would be a minor but likely helpful fix.

### Additional details

I noticed that the other link "Advanced text formatting > Description lists" also does not link directly to relevant information. Could potentially be improved by rewording the link text to be more specific or linking to a different page, such as [this one](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Text_styling/Styling_lists).

Since this wasn't in the scope of the original issue, I left it alone for now.

### Related issues and pull requests

Fixes #83 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
