### PR TITLE
fix(build): use markdownlint-cli2 --fix instead of removed bin

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -15,7 +15,7 @@ pre-commit:
             run: npx prettier --write {staged_files}
             stage_fixed: true
           - name: Markdownlint
-            run: npx markdownlint-cli2-fix {staged_files}
+            run: npx markdownlint-cli2 --fix {staged_files}
             stage_fixed: true
 
 post-merge:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "prepare": "lefthook install",
-    "fix": "prettier --ignore-unknown --write \"**/*.md\" && markdownlint-cli2-fix \"**/*.md\"",
+    "fix": "prettier --ignore-unknown --write \"**/*.md\" && markdownlint-cli2 --fix \"**/*.md\"",
     "lint": "prettier --ignore-unknown --check \"**/*.md\" && markdownlint-cli2 \"**/*.md\""
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Updates both the `fix` npm script and the lefthook config to use `markdownlint-cli2 --fix` instead of `markdownlint-cli2-fix`.

### Motivation

The `markdownlint-cli2-fix` bin was removed in `markdownlint-cli2` 0.12.0, so `npx markdownlint-cli2-fix` now tries to execute an unrelated package.

### Additional details

Originally added in https://github.com/mdn/curriculum/commit/40f43958b6c5373c915e01393328d3e06b5a9b0c when the repo used `markdownlint-cli2` 0.8.1 which provided the `markdownlint-cli2-fix` binary from 0.0.13 (https://github.com/DavidAnson/markdownlint-cli2/commit/d98ebd50c8fd7b21456a5bbcec92b217a6956c08) until 0.12.0 (https://github.com/DavidAnson/markdownlint-cli2/commit/6e3e72239e74871da6be2fda429799199e629e3a).

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.
