### PR TITLE
fix(ci): pin npx rari to @mdn/rari package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CURRICULUM_ROOT: ${{ github.workspace }}/mdn/curriculum
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx rari build --no-basic --curriculum --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
+        run: npx @mdn/rari build --no-basic --curriculum --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
 
       - name: Report
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Description

Pin the `rari` invocation in `.github/workflows/test.yml` to its scoped provider:

- `npx rari build …` → `npx @mdn/rari build …`

## Motivation

Prevent a dependency-confusion fallback in `npx rari`.

## Additional details

`npx rari` resolves to the intended bin only while a local `rari` binary is present (here, transitively via content's `@mdn/rari`, pulled through `@mdn/fred`). If that chain breaks, npm silently downloads and executes a registry package literally named `rari` — owned by an **unrelated third party**, not MDN. In CI, `npx` assumes `--yes`, so the fallback fetch happens with no prompt. Invoking `@mdn/rari` directly guarantees the intended bin.

The `markdownlint-cli2-fix` item for this repo is handled separately in #123.

## Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.
