### PR TITLE
ci(auto-cleanup-bot): remove push trigger

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -1,7 +1,6 @@
 name: Create curriculum auto-fix PR
 
 on:
-  push:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes the `push` trigger of the `auto-cleanup-bot`.

### Motivation

Avoid that the workflow runs (and fails) on every push.

### Additional details

This is an unintentional left-over from https://github.com/mdn/curriculum/pull/125.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
