### PR TITLE
build(npm): allowlist + enforce dependency install scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+strict-allow-scripts=true

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "devDependencies": {
     "lefthook": "^2.0.15"
+  },
+  "allowScripts": {
+    "lefthook": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/mdn/curriculum/issues"
   },
   "homepage": "https://github.com/mdn/curriculum#readme",
-  "packageManager": "npm@11.6.2",
+  "packageManager": "npm@11.19.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
### Description

Add an `allowScripts` entry for `lefthook`, enable `strict-allow-scripts`, and bump the npm pin.

### Motivation

npm 12 no longer runs dependency install scripts unless the root `package.json` allowlists them. `lefthook` is the only dependency with one; its `postinstall` registers the git hooks from `.lefthook.yml`, so without the entry contributors silently lose pre-commit hooks. CI is unaffected (the hook install skips when `CI` is set; the binary ships as an optional dependency). The root `prepare` script also runs `lefthook install`; the entry is kept for consistency with the other MDN repos.

### Additional details

- Entries are name-only (`--no-allow-scripts-pin`), so Dependabot bumps do not need re-approval commits, at the cost of trusting future versions of the listed packages.
- `strict-allow-scripts=true` in `.npmrc` turns an uncovered install script into a hard `npm ci` error (honored by npm 11.16+, not only npm 12).
- `packageManager` bumped from npm 11.6.2 to 11.19.0, which understands `allowScripts`; `.nvmrc` already tracks the latest Node 24.
- Verified: `npm ci --strict-allow-scripts` passes on npm 12.0.2 and 11.19.0; `npm approve-scripts --allow-scripts-pending` reports nothing.

### Related issues and pull requests

Part of mdn/fred#1868.
